### PR TITLE
Allow headers to be passed to proxy

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -306,6 +306,7 @@ class HTTPAdapter(BaseAdapter):
                 raise InvalidProxyURL("Please check proxy URL. It is malformed"
                                       " and could be missing the host.")
             proxy_manager = self.proxy_manager_for(proxy)
+            proxy_manager.proxy_headers.update(proxies.get('headers', {}))
             conn = proxy_manager.connection_from_url(url)
         else:
             # Only scheme should be lower case


### PR DESCRIPTION
Adding a `header` field to `proxies` will pass any headers to the proxy connection.